### PR TITLE
Add permission check on Android API >= 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 A simple React Native plugin to switch a flashlight on/off.
 
-Currently supports both iOS (>= 8.0) and Android.
+Currently supports both iOS (>= 8.0) and Android (all versions).
+
+Applies the permission checks on Android API >=25 devices. Below API 25, Android will automatically require the user to accept permissions on install / update.
 
 ## Install
 
@@ -15,12 +17,36 @@ react-native link react-native-torch
 
 ## Usage
 
+### Without permissions check
+
 ```js
 import Torch from 'react-native-torch';
 
-Torch.switchState(true) // Turn ON
-Torch.switchState(false) // Turn OFF
+Torch.switchState(true); // Turn ON
+Torch.switchState(false); // Turn OFF
+```
+
+### With extra permission check and dialog (Android only)
+
+```js
+import Torch from 'react-native-torch';
+import { Platform } from 'react-native';
+
+if (Platform.OS === 'ios') {
+	Torch.switchState(this.isTorchOn);
+} else {
+	const cameraAllowed = await Torch.requestCameraPermission(
+		'Camera Permissions', // dialog title
+		'We require camera permissions to use the torch on the back of your phone.' // dialog body
+	);
+
+	if (cameraAllowed) {
+		Torch.switchState(this.isTorchOn);
+	}
+}
 ```
 
 A demo application [TorchDemo](https://github.com/ludo/TorchDemo) is also
 available.
+
+Android version has flow support.

--- a/android/src/main/java/com/cubicphuse/RCTTorch/RCTTorchModule.java
+++ b/android/src/main/java/com/cubicphuse/RCTTorch/RCTTorchModule.java
@@ -5,25 +5,19 @@
 package com.cubicphuse.RCTTorch;
 
 import android.content.Context;
+import android.hardware.Camera;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraManager;
 import android.os.Build;
 
-import android.hardware.Camera;
-import android.hardware.Camera.Parameters;
-import android.content.pm.PackageManager;
-
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 public class RCTTorchModule extends ReactContextBaseJavaModule {
     private final ReactApplicationContext myReactContext;
-    public boolean isTorchOn = false;
-    protected Camera camera;
-    protected Parameters params;
+    private Boolean isTorchOn = false;
+    private Camera camera;
 
     public RCTTorchModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -49,20 +43,19 @@ public class RCTTorchModule extends ReactContextBaseJavaModule {
             } catch (CameraAccessException e) {
                 e.printStackTrace();
             }
-        }
-        else {
+        } else {
+            Camera.Parameters params;
+
             if (!isTorchOn) {
                 camera = Camera.open();
                 params = camera.getParameters();
-
-                params.setFlashMode(Parameters.FLASH_MODE_TORCH);
+                params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
                 camera.setParameters(params);
                 camera.startPreview();
                 isTorchOn = true;
-            }
-            else {
+            } else {
                 params = camera.getParameters();
-                params.setFlashMode(Parameters.FLASH_MODE_OFF);
+                params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
 
                 camera.setParameters(params);
                 camera.stopPreview();
@@ -72,4 +65,3 @@ public class RCTTorchModule extends ReactContextBaseJavaModule {
         }
     }
 }
-

--- a/index.android.js
+++ b/index.android.js
@@ -1,0 +1,50 @@
+// @flow
+import { NativeModules, PermissionsAndroid } from 'react-native';
+
+const { Torch } = NativeModules;
+
+async function requestCameraPermission(
+  title: string,
+  message: string
+): Boolean {
+  try {
+    const hasCameraPermission = await PermissionsAndroid.check(
+      PermissionsAndroid.PERMISSIONS.CAMERA
+    );
+
+    if (hasCameraPermission) {
+      return true;
+    }
+
+    const granted = await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.CAMERA,
+      {
+        title,
+        message
+      }
+    );
+
+    if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+      return true;
+    }
+    return false;
+  } catch (err) {
+    console.warn(err);
+    return false;
+  }
+}
+
+const TorchWithPermissionCheck = {
+  ...Torch,
+  requestCameraPermission
+};
+
+/**
+ * This exposes the native `Torch` module as a JS module.
+ *
+ * `Torch` has one function `switchState` which takes one parameter:
+ *
+ * `Boolean newState`: A boolean indicating next torch status.
+ */
+
+export default TorchWithPermissionCheck;

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,5 @@
 import { NativeModules } from 'react-native';
+
 const { Torch } = NativeModules;
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,22 +1,13 @@
 {
   "name": "react-native-torch",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Torch/flashlight for react-native",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/ludo/react-native-torch"
   },
-  "keywords": [
-    "react",
-    "react-component",
-    "react-native",
-    "ios",
-    "android",
-    "device",
-    "torch",
-    "flashlight"
-  ],
+  "keywords": ["react", "react-component", "react-native", "ios", "android", "device", "torch", "flashlight"],
   "author": "Ludo van den Boom <ludo@cubicphuse.nl> (https://github.com/ludo)",
   "license": "MIT"
 }


### PR DESCRIPTION
- Adds a permission dialog to explain the rationale for Camera permissions on newer versions of Android (API 25 and above)
- Checks for API23, and uses faster implementation for newer versions and compatible versions for older ones
- Adds extra function to Android version, to request camera permissions