### PR TITLE
fix#7 - rm GCM dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,4 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
 }


### PR DESCRIPTION
Hi @ludo,

As suggested in [issue#7,](https://github.com/ludo/react-native-torch/issues/7) this PR is to remove the Google Cloud Messaging dependency from the Android project.

Olivier