### PR TITLE
Added minimal .npmignore to avoid publishing build folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+ios/derivedData/
+android/build/


### PR DESCRIPTION
`react-native-torch@1.1.4` npm package weights 30.2MB when zipped, and 105MB when deflated.
This is mostly due to the fact that `/android/build` folder was published as a part of the package.
A package with no build folder weights 6.9KB, just for comparison.

I would very much appreciate if this could be merged, and a new, more lightweight version published. To save us time and bits.

Thanks! 